### PR TITLE
add_bower_support_back

### DIFF
--- a/.bower.json
+++ b/.bower.json
@@ -1,0 +1,29 @@
+{
+  "name": "chartist-plugin-axistitle",
+  "version": "0.0.5",
+  "main": [
+    "./dist/chartist-plugin-axistitle.min.js"
+  ],
+  "dependencies": {
+    "chartist": "~0.10.1"
+  },
+  "ignore": [
+    ".*",
+    "Gruntfile.js",
+    "package.json",
+    "node_modules",
+    "src",
+    "test",
+    "tasks"
+  ],
+  "homepage": "https://github.com/alexstanbury/chartist-plugin-axistitle",
+  "_release": "0.0.5",
+  "_resolution": {
+    "type": "version",
+    "tag": "0.0.5",
+    "commit": "03b5ab4b50372a8b6dfb3add13e853b3abbb9b50"
+  },
+  "_source": "https://github.com/alexstanbury/chartist-plugin-axistitle.git",
+  "_target": "0.0.5",
+  "_originalSource": "chartist-plugin-axistitle"
+}


### PR DESCRIPTION
add `main` keyword for wiredep detect and add to kiotaz header automatically